### PR TITLE
Enhancement/limit watering date attributes

### DIFF
--- a/web/Views/Plants/Create.cshtml
+++ b/web/Views/Plants/Create.cshtml
@@ -44,7 +44,7 @@
         <div class ="row">
             <div class="form-group col-md-5">
                 <label asp-for="LastWateredDate" class="control-label"></label>
-                <input type="date" id="LastWateredDateDatePicker" asp-for="LastWateredDate" class="form-control" />
+                <input type="date" id="LastWateredDatePickerCreate" asp-for="LastWateredDate" class="form-control" />
                 @* <input asp-for="LastWateredDate" class="form-control" /> *@
                 <span asp-validation-for="LastWateredDate" class="text-danger"></span>
             </div>
@@ -91,5 +91,7 @@
 
 
 
-
+<script>
+    LastWateredDatePickerCreate.max = new Date().toISOString().split("T")[0];
+</script>
 

--- a/web/Views/Plants/Edit.cshtml
+++ b/web/Views/Plants/Edit.cshtml
@@ -46,7 +46,8 @@
     <div class ="row">
         <div class="form-group col-md-5">
             <label asp-for="LastWateredDate" class="control-label"></label>
-            <input asp-for="LastWateredDate" class="form-control" />
+            <input type="date" id="LastWateredDatePickerEdit" asp-for="LastWateredDate" class="form-control" />
+            @* <input asp-for="LastWateredDate" class="form-control" /> *@
             <span asp-validation-for="LastWateredDate" class="text-danger"></span>
         </div>
         <div class="form-group col-md-5">
@@ -90,3 +91,6 @@
     <a asp-action="Index">Back to List</a>
 </div>
 
+<script>
+    LastWateredDatePickerEdit.max = new Date().toISOString().split("T")[0];
+</script>

--- a/web/wwwroot/js/site.js
+++ b/web/wwwroot/js/site.js
@@ -5,4 +5,6 @@
 
 
 // Limit last watered date input range. Set max date to today.
-LastWateredDateDatePicker.max = new Date().toISOString().split("T")[0];
+
+
+


### PR DESCRIPTION
When creating or editing a plant the last watered attribute date should always be in the past or present. 